### PR TITLE
Avoid to check `whatever` is None in conversion function.

### DIFF
--- a/grassmann_tensor/tensor.py
+++ b/grassmann_tensor/tensor.py
@@ -78,7 +78,7 @@ class GrassmannTensor:
             case str():
                 assert device is None, "Duplicate device specification."
                 device = torch.device(whatever)
-            case None:
+            case _:
                 pass
         match (device, dtype):
             case (None, None):


### PR DESCRIPTION
As it is always None if the program run here.